### PR TITLE
Fix postcss export

### DIFF
--- a/nepalingo-web/postcss.config.js
+++ b/nepalingo-web/postcss.config.js
@@ -4,7 +4,10 @@
 // https://github.com/vitejs/vite/issues/15869#issuecomment-1939414914
 // https://github.com/vitejs/vite/pull/15235
 
-export const plugins = {
-  tailwindcss: {},
-  autoprefixer: {},
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };
+

--- a/nepalingo-web/src/App.tsx
+++ b/nepalingo-web/src/App.tsx
@@ -5,6 +5,7 @@ function App() {
   return (
     <>
       <Header />
+      <p className="bg-blue-500">Blue Test</p>
     </>
   );
 }


### PR DESCRIPTION
The shape of the postcss export was incorrect. It should export an object with the plugins inside of that object. For some reason it was exporting just the object inside the plugins key.