### PR TITLE
Set login/home pages to show on root endpoint

### DIFF
--- a/nepalingo-web/src/App.tsx
+++ b/nepalingo-web/src/App.tsx
@@ -39,11 +39,10 @@ const App: React.FC = () => {
   return (
     <Router>
       <Routes>
-        <Route path="/" element={<Header />} />
         <Route path="/login" element={<User_auth />} />
-        {/* Protect the /home route, redirect to /login if not authenticated */}
+        {/* Protect the / route, redirect to /login if not authenticated */}
         <Route
-          path="/home"
+          path="/"
           element={isAuthenticated ? <Home /> : <Navigate to="/login" />}
         />
         {/* Default route redirects to /login */}

--- a/nepalingo-web/src/App.tsx
+++ b/nepalingo-web/src/App.tsx
@@ -7,7 +7,6 @@ import {
 } from "react-router-dom";
 import User_auth from "./components/userAuth/UserAuth";
 import Home from "./pages/Home/Home";
-import Header from "./components/Header";
 import supabase from "./components/userAuth/supabaseClient";
 
 const App: React.FC = () => {


### PR DESCRIPTION
This will make it so that those who go to our domain will immediately be greeted with login then the homepage. This also fixes the redirect on the email verification step to redirect to login page instead of the Header component