### PR TITLE
Improve pronunciation playback with shared audio hook (Vibe Kanban)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.python_modules/

--- a/nepalingo-web/src/components/Card.tsx
+++ b/nepalingo-web/src/components/Card.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faVolumeHigh } from "@fortawesome/free-solid-svg-icons";
 import { useLanguage } from "@/hooks/Langauge";
+import useAudioPlayer from "@/hooks/useAudioPlayer";
 
 interface CardProps {
   Word: string;
@@ -22,25 +23,12 @@ const Card: React.FC<CardProps> = ({
   PronounciationUrl,
   viewType,
 }) => {
-  const [audio, setAudio] = useState<HTMLAudioElement | null>(null);
   const { selectedLanguage } = useLanguage();
+  const { togglePlayback } = useAudioPlayer(PronounciationUrl);
 
-  const handlePronunciation = (event: React.MouseEvent) => {
+  const handlePronunciation = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    if (PronounciationUrl) {
-      if (audio) {
-        if (!audio.paused) {
-          audio.pause();
-          audio.currentTime = 0;
-        } else {
-          audio.play();
-        }
-      } else {
-        const newAudio = new Audio(PronounciationUrl);
-        setAudio(newAudio);
-        newAudio.play();
-      }
-    }
+    togglePlayback();
   };
 
   return (

--- a/nepalingo-web/src/components/Card.tsx
+++ b/nepalingo-web/src/components/Card.tsx
@@ -31,6 +31,22 @@ const Card: React.FC<CardProps> = ({
     togglePlayback();
   };
 
+  const PronunciationButton = () => {
+    if (!PronounciationUrl) {
+      return null;
+    }
+
+    return (
+      <button
+        type="button"
+        onClick={handlePronunciation}
+        className="absolute right-4 bottom-4 z-10 text-white"
+      >
+        <FontAwesomeIcon icon={faVolumeHigh} />
+      </button>
+    );
+  };
+
   return (
     <div className="relative rounded-2xl overflow-hidden shadow-2xl w-[300px] h-[400px] sm:w-[300px] sm:h-[400px] md:w-[350px] md:h-[450px] lg:w-[519px] lg:h-[600px]">
       {/* Front View */}
@@ -60,14 +76,7 @@ const Card: React.FC<CardProps> = ({
             <p className="text-lg text-white sm:text-lg md:text-xl lg:text-2xl">
               {Pronunciation}
             </p>
-            {PronounciationUrl && (
-              <button
-                onClick={handlePronunciation}
-                className="absolute right-4 bottom-4 z-10 text-white"
-              >
-                <FontAwesomeIcon icon={faVolumeHigh} />
-              </button>
-            )}
+            <PronunciationButton />
           </div>
           <div className="relative w-full h-[30%] rounded-b-2xl overflow-hidden flex items-center justify-center">
             {ImageUrl && (
@@ -113,14 +122,7 @@ const Card: React.FC<CardProps> = ({
             <p className="text-lg sm:text-lg md:text-xl lg:text-2xl">
               {Pronunciation}
             </p>
-            {PronounciationUrl && (
-              <button
-                onClick={handlePronunciation}
-                className="absolute right-4 bottom-4 z-10 text-white"
-              >
-                <FontAwesomeIcon icon={faVolumeHigh} />
-              </button>
-            )}
+            <PronunciationButton />
           </div>
           <div className="relative h-[70%] w-full rounded-b-2xl overflow-hidden flex items-center justify-center">
             {ImageUrl && (

--- a/nepalingo-web/src/components/SearchResponseCard.tsx
+++ b/nepalingo-web/src/components/SearchResponseCard.tsx
@@ -1,40 +1,16 @@
 import { Meaning } from "@/hooks/useDictionary";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faVolumeHigh } from "@fortawesome/free-solid-svg-icons";
+import useAudioPlayer from "@/hooks/useAudioPlayer";
 
 const SearchResponseCard = ({ meaning }: { meaning: Meaning }) => {
-  const [audio, setAudio] = useState<HTMLAudioElement | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (audio) {
-        audio.pause();
-        audio.currentTime = 0;
-      }
-    };
-  }, [audio]);
+  const { togglePlayback } = useAudioPlayer(meaning.audio?.uri);
 
   const handlePronunciation = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
 
-    if (!meaning.audio?.uri) {
-      return;
-    }
-
-    if (audio) {
-      if (!audio.paused) {
-        audio.pause();
-        audio.currentTime = 0;
-      } else {
-        audio.currentTime = 0;
-        void audio.play();
-      }
-    } else {
-      const newAudio = new Audio(meaning.audio.uri);
-      setAudio(newAudio);
-      void newAudio.play();
-    }
+    togglePlayback();
   };
 
   return (

--- a/nepalingo-web/src/components/SearchResponseCard.tsx
+++ b/nepalingo-web/src/components/SearchResponseCard.tsx
@@ -1,7 +1,42 @@
 import { Meaning } from "@/hooks/useDictionary";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faVolumeHigh } from "@fortawesome/free-solid-svg-icons";
 
 const SearchResponseCard = ({ meaning }: { meaning: Meaning }) => {
+  const [audio, setAudio] = useState<HTMLAudioElement | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (audio) {
+        audio.pause();
+        audio.currentTime = 0;
+      }
+    };
+  }, [audio]);
+
+  const handlePronunciation = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+
+    if (!meaning.audio?.uri) {
+      return;
+    }
+
+    if (audio) {
+      if (!audio.paused) {
+        audio.pause();
+        audio.currentTime = 0;
+      } else {
+        audio.currentTime = 0;
+        void audio.play();
+      }
+    } else {
+      const newAudio = new Audio(meaning.audio.uri);
+      setAudio(newAudio);
+      void newAudio.play();
+    }
+  };
+
   return (
     <div
       key={meaning.meaningOriginal}
@@ -19,12 +54,15 @@ const SearchResponseCard = ({ meaning }: { meaning: Meaning }) => {
               </p>
             )}
           </div>
-          {meaning.audio && (
-            <audio
-              controls
-              src={meaning.audio.uri}
-              className="max-w-28 "
-            ></audio>
+          {meaning.audio?.uri && (
+            <button
+              type="button"
+              onClick={handlePronunciation}
+              className="self-start text-white text-2xl transition-colors hover:text-primary focus-visible:outline-none"
+              aria-label={`Play pronunciation for ${meaning.meaningOriginal}`}
+            >
+              <FontAwesomeIcon icon={faVolumeHigh} />
+            </button>
           )}
         </div>
         <div className="flex flex-row flex-wrap gap-2 mt-2">

--- a/nepalingo-web/src/hooks/useAudioPlayer.ts
+++ b/nepalingo-web/src/hooks/useAudioPlayer.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef } from "react";
+
+const resetAudio = (audio: HTMLAudioElement | null) => {
+  if (!audio) {
+    return;
+  }
+
+  audio.pause();
+  audio.currentTime = 0;
+};
+
+const useAudioPlayer = (audioUrl?: string) => {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const lastUrlRef = useRef<string | undefined>(audioUrl);
+
+  useEffect(() => {
+    return () => {
+      resetAudio(audioRef.current);
+      audioRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!audioUrl) {
+      resetAudio(audioRef.current);
+      audioRef.current = null;
+    } else if (lastUrlRef.current && lastUrlRef.current !== audioUrl) {
+      resetAudio(audioRef.current);
+      audioRef.current = null;
+    }
+
+    lastUrlRef.current = audioUrl;
+  }, [audioUrl]);
+
+  const togglePlayback = useCallback(() => {
+    if (!audioUrl) {
+      return;
+    }
+
+    const existingAudio = audioRef.current;
+
+    if (existingAudio) {
+      if (!existingAudio.paused) {
+        resetAudio(existingAudio);
+      } else {
+        existingAudio.currentTime = 0;
+        const playPromise = existingAudio.play();
+        if (playPromise) {
+          void playPromise.catch(() => undefined);
+        }
+      }
+
+      return;
+    }
+
+    const newAudio = new Audio(audioUrl);
+    audioRef.current = newAudio;
+    const playPromise = newAudio.play();
+    if (playPromise) {
+      void playPromise.catch(() => undefined);
+    }
+  }, [audioUrl]);
+
+  return { togglePlayback };
+};
+
+export default useAudioPlayer;

--- a/nepalingo-web/src/hooks/useAudioPlayer.ts
+++ b/nepalingo-web/src/hooks/useAudioPlayer.ts
@@ -11,7 +11,6 @@ const resetAudio = (audio: HTMLAudioElement | null) => {
 
 const useAudioPlayer = (audioUrl?: string) => {
   const [audio, setAudio] = useState<HTMLAudioElement | null>(null);
-  const [lastUrl, setLastUrl] = useState<string | undefined>(audioUrl);
 
   const clearAudio = useCallback(() => {
     setAudio((currentAudio) => {
@@ -30,22 +29,8 @@ const useAudioPlayer = (audioUrl?: string) => {
   }, [audio]);
 
   useEffect(() => {
-    if (!audioUrl) {
-      clearAudio();
-      if (lastUrl !== undefined) {
-        setLastUrl(undefined);
-      }
-      return;
-    }
-
-    if (lastUrl && lastUrl !== audioUrl) {
-      clearAudio();
-    }
-
-    if (lastUrl !== audioUrl) {
-      setLastUrl(audioUrl);
-    }
-  }, [audioUrl, lastUrl, clearAudio]);
+    clearAudio();
+  }, [audioUrl, clearAudio]);
 
   const togglePlayback = useCallback(() => {
     if (!audioUrl) {

--- a/nepalingo-web/src/hooks/useAudioPlayer.ts
+++ b/nepalingo-web/src/hooks/useAudioPlayer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const resetAudio = (audio: HTMLAudioElement | null) => {
   if (!audio) {
@@ -10,55 +10,72 @@ const resetAudio = (audio: HTMLAudioElement | null) => {
 };
 
 const useAudioPlayer = (audioUrl?: string) => {
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const lastUrlRef = useRef<string | undefined>(audioUrl);
+  const [audio, setAudio] = useState<HTMLAudioElement | null>(null);
+  const [lastUrl, setLastUrl] = useState<string | undefined>(audioUrl);
 
-  useEffect(() => {
-    return () => {
-      resetAudio(audioRef.current);
-      audioRef.current = null;
-    };
+  const clearAudio = useCallback(() => {
+    setAudio((currentAudio) => {
+      if (currentAudio) {
+        resetAudio(currentAudio);
+      }
+
+      return null;
+    });
   }, []);
 
   useEffect(() => {
+    return () => {
+      resetAudio(audio);
+    };
+  }, [audio]);
+
+  useEffect(() => {
     if (!audioUrl) {
-      resetAudio(audioRef.current);
-      audioRef.current = null;
-    } else if (lastUrlRef.current && lastUrlRef.current !== audioUrl) {
-      resetAudio(audioRef.current);
-      audioRef.current = null;
+      clearAudio();
+      if (lastUrl !== undefined) {
+        setLastUrl(undefined);
+      }
+      return;
     }
 
-    lastUrlRef.current = audioUrl;
-  }, [audioUrl]);
+    if (lastUrl && lastUrl !== audioUrl) {
+      clearAudio();
+    }
+
+    if (lastUrl !== audioUrl) {
+      setLastUrl(audioUrl);
+    }
+  }, [audioUrl, lastUrl, clearAudio]);
 
   const togglePlayback = useCallback(() => {
     if (!audioUrl) {
       return;
     }
 
-    const existingAudio = audioRef.current;
+    setAudio((currentAudio) => {
+      if (currentAudio) {
+        if (!currentAudio.paused) {
+          resetAudio(currentAudio);
+          return null;
+        }
 
-    if (existingAudio) {
-      if (!existingAudio.paused) {
-        resetAudio(existingAudio);
-      } else {
-        existingAudio.currentTime = 0;
-        const playPromise = existingAudio.play();
+        currentAudio.currentTime = 0;
+        const playPromise = currentAudio.play();
         if (playPromise) {
           void playPromise.catch(() => undefined);
         }
+
+        return currentAudio;
       }
 
-      return;
-    }
+      const newAudio = new Audio(audioUrl);
+      const playPromise = newAudio.play();
+      if (playPromise) {
+        void playPromise.catch(() => undefined);
+      }
 
-    const newAudio = new Audio(audioUrl);
-    audioRef.current = newAudio;
-    const playPromise = newAudio.play();
-    if (playPromise) {
-      void playPromise.catch(() => undefined);
-    }
+      return newAudio;
+    });
   }, [audioUrl]);
 
   return { togglePlayback };


### PR DESCRIPTION
## What changed
- Added a reusable `useAudioPlayer` hook to manage pronunciation audio playback from a URL.
- Updated `SearchResponseCard` to replace the inline `<audio controls>` UI with a small speaker icon button (with an accessible `aria-label`).
- Updated `Card` to use the shared audio hook and a small `PronunciationButton` helper to avoid duplicating playback logic.
- Added `.python_modules/` to `.gitignore`.

## Why
Some users were seeing inconsistent/awkward audio playback UX and duplicated playback logic across components. This change centralizes the audio behavior and makes the UI more consistent and lightweight.

## Implementation details
- `useAudioPlayer` toggles play/stop, resets audio to the start when replaying, and cleans up on unmount.
- When the provided `audioUrl` changes, the hook clears any existing audio instance to avoid playing stale audio.
- `HTMLMediaElement.play()` promise rejections are safely ignored to avoid noisy console errors (e.g., autoplay restrictions).

This PR was written using [Vibe Kanban](https://vibekanban.com)
